### PR TITLE
Allow trade offer refresh configuration

### DIFF
--- a/Bin/Debug/settings-template.json
+++ b/Bin/Debug/settings-template.json
@@ -9,6 +9,7 @@
             "Username":"BOT USERNAME",
             "Password":"BOT PASSWORD",
             "ApiKey":"Bot specific apiKey",
+			"TradeOfferRefreshRate": 2000,
             "DisplayName":"TestBot",
             "ChatResponse":"Hi there bro",
             "logFile": "TestBot.log",

--- a/Bin/Debug/settings-template.json
+++ b/Bin/Debug/settings-template.json
@@ -9,7 +9,7 @@
             "Username":"BOT USERNAME",
             "Password":"BOT PASSWORD",
             "ApiKey":"Bot specific apiKey",
-			"TradeOfferRefreshRate": 2000,
+            "TradeOfferRefreshRate": 2000,
             "DisplayName":"TestBot",
             "ChatResponse":"Hi there bro",
             "logFile": "TestBot.log",

--- a/Bin/Release/settings-template.json
+++ b/Bin/Release/settings-template.json
@@ -9,6 +9,7 @@
             "Username":"BOT USERNAME",
             "Password":"BOT PASSWORD",
             "ApiKey":"Bot specific apiKey",
+            "TradeOfferRefreshRate": 2000,
             "DisplayName":"TestBot",
             "ChatResponse":"Hi there bro",
             "logFile": "TestBot.log",

--- a/SteamAPI/TradeOffer.cs
+++ b/SteamAPI/TradeOffer.cs
@@ -20,13 +20,15 @@ namespace SteamAPI
         private List<ulong> ReceivedPendingTradeOffers;
         private string AccountApiKey;
         private bool ShouldCheckPendingTradeOffers;
+        private int TradeOfferRefreshRate;
 
-        public TradeOffers(SteamID botId, SteamWeb steamWeb, string accountApiKey, List<ulong> pendingTradeOffers = null)
+        public TradeOffers(SteamID botId, SteamWeb steamWeb, string accountApiKey, int TradeOfferRefreshRate, List<ulong> pendingTradeOffers = null)
         {
             this.BotId = botId;
             this.SteamWeb = steamWeb;
             this.AccountApiKey = accountApiKey;
             this.ShouldCheckPendingTradeOffers = true;
+            this.TradeOfferRefreshRate = TradeOfferRefreshRate;
 
             if (pendingTradeOffers == null)
                 this.OurPendingTradeOffers = new List<ulong>();
@@ -744,7 +746,7 @@ namespace SteamAPI
                         }
                     }
                 }
-                System.Threading.Thread.Sleep(2000);
+                System.Threading.Thread.Sleep(TradeOfferRefreshRate);
             }
         }
 

--- a/SteamBot/Bot.cs
+++ b/SteamBot/Bot.cs
@@ -80,6 +80,11 @@ namespace SteamBot
         /// The prefix shown before bot's display name.
         /// </summary>
         public readonly string DisplayNamePrefix;
+
+        /// <summary>
+        /// The time in milliseconds between checking for new trade offers.
+        /// </value>
+        public readonly int TradeOfferRefreshRate;
         #endregion
 
         #region Public variables
@@ -131,6 +136,7 @@ namespace SteamBot
             };
             DisplayName  = config.DisplayName;
             ChatResponse = config.ChatResponse;
+            TradeOfferRefreshRate = config.TradeOfferRefreshRate;
             DisplayNamePrefix = config.DisplayNamePrefix;
             Admins = config.Admins;
             ApiKey = !String.IsNullOrEmpty(config.ApiKey) ? config.ApiKey : apiKey;
@@ -503,7 +509,7 @@ namespace SteamBot
             
             cookiesAreInvalid = false;
 
-            TradeOffers = new TradeOffers(SteamUser.SteamID, SteamWeb, ApiKey);
+            TradeOffers = new TradeOffers(SteamUser.SteamID, SteamWeb, ApiKey, TradeOfferRefreshRate);
             TradeOffers.TradeOfferAccepted += TradeOffers_TradeOfferAccepted;
             TradeOffers.TradeOfferDeclined += TradeOffers_TradeOfferDeclined;
             TradeOffers.TradeOfferReceived += TradeOffers_TradeOfferReceived;

--- a/SteamBot/Configuration.cs
+++ b/SteamBot/Configuration.cs
@@ -150,6 +150,7 @@ namespace SteamBot
             public string Username { get; set; }
             public string Password { get; set; }
             public string ApiKey { get; set; }
+            public int TradeOfferRefreshRate { get; set; }
             public string DisplayName { get; set; }
             public string ChatResponse { get; set; }
             public string LogFile { get; set; }


### PR DESCRIPTION
Allows for trade offer refresh configuration for each individual bot. The main reason this is useful is it decreases the number of times it contacts the steam servers and as many running SteamBot might have noticed it has a tendency (every once in a while) to crash or have errors when it interacts with the steam servers.
