### PR TITLE
Causes NullReferenceException in some cases

### DIFF
--- a/SteamBot/Bot.cs
+++ b/SteamBot/Bot.cs
@@ -988,7 +988,7 @@ namespace SteamBot
                 //StartBot();
             }
 
-            Log.Dispose();
+            DisposeLog();
         }
 
         private void BackgroundWorkerOnDoWork(object sender, DoWorkEventArgs doWorkEventArgs)


### PR DESCRIPTION
Caused when calling StopBot() because it disposes the log in it already. + safer this way
